### PR TITLE
Update to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
     default: true
 runs:
-  using: node12
+  using: node16
   main: ./dist/index.js
 branding:
   icon: trash-2


### PR DESCRIPTION
As per https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ Github has deprecated all Actions using `node12` as it's execution engine.

Should solve #8 