### PR TITLE
fix: mark the action as failed on uncaught errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29419,7 +29419,8 @@ const utils_1 = __nccwpck_require__(1314);
             }
         }
         catch (err) {
-            core.error(`${err}`);
+            // @ts-ignore
+            core.setFailed(err);
         }
     });
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { fail } from "./utils";
             );
         }
     } catch (err) {
-        core.error(`${err}`);
+        // @ts-ignore
+        core.setFailed(err);
     }
 })();


### PR DESCRIPTION
Currently, the action only logs errors during the configuration phase and for internal bugs but does not mark the step as failed. This change fixes this by failing the step if any error is thrown (and not caught elsewhere).

See [this workflow run](https://github.com/TheMrMilchmann/setup-msvc-dev/actions/runs/7322517809/job/19944105704?pr=164#step:2:9) for example without this change and [this run](https://github.com/TheMrMilchmann/setup-msvc-dev/actions/runs/7367366912/job/20051625633) with the change.