### PR TITLE
Upgrade Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: "true"
 runs:
-  using: node20
+  using: node24
   main: ./dist/index.js
 branding:
   icon: trash-2


### PR DESCRIPTION
As required for https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/